### PR TITLE
Upgrade SerialPort from 2.0.5 to 3.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "graceful-fs": "^4.1.2",
     "intel-hex": "^0.1.1",
     "minimist": "^1.2.0",
-    "serialport": "^2.0.5",
+    "serialport": "^3.1.2",
     "stk500": "git://github.com/noopkat/js-stk500v1#avrgirl",
     "stk500-v2": "^1.0.1"
   },


### PR DESCRIPTION
3.1.2 will probably be the last of the serial port 3.x releases. 3.x didn't change the api beyond not removing event handlers which don’t seem to be used here. It primarily fixes bugs.

https://github.com/EmergingTechnologyAdvisors/node-serialport/blob/master/changelog.md#version-205 

Notable changes

 - Node 6 support
 - Memory leaks removed
 - possible error handling (`port.on(‘error’)` often didn’t work in the past as all event handlers were removed on disconnect or close)
 - Much better error messages
 - Bug fixes around opening and closing ports on OSX

I checked the usage in the following packages and they appear to not cause any issues with the changes.

 - stk500
 - chip.avr.avr109

Helps #57
Closes #68