### PR TITLE
Add ME Auriga as mega board, update stk500-v2 

### DIFF
--- a/boards.js
+++ b/boards.js
@@ -112,7 +112,7 @@ var boards = [
     byteDelay:0x00,
     pollValue:0x53,
     pollIndex:0x03,
-    productId: ['0x0042', '0x6001', '0x0010'],
+    productId: ['0x0042', '0x6001', '0x0010', '0x7523'],
     protocol: 'stk500v2'
   },
   {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "minimist": "^1.2.0",
     "serialport": "^4.0.1",
     "stk500": "git://github.com/noopkat/js-stk500v1#avrgirl",
-    "stk500-v2": "^1.0.1"
+    "stk500-v2": "^1.0.2"
   },
   "devDependencies": {
     "avrga-tester": "1.x",


### PR DESCRIPTION
Hi!
im doing a little research with an Arduino Mega modification called [ME Auriga](http://www.makeblock.com/electronic-robot-kit-series-STEM/me-auriga). Looks fine and can upload simple codes, so i add the productId. 

Also update the stk500-v2 library to 1.0.2 (its a minor change to fix a bug when is used inside a chrome extension with browserify).

Thanks! 🎄 