### PR TITLE
Use options.debug in protocol as debug function

### DIFF
--- a/lib/protocol.js
+++ b/lib/protocol.js
@@ -3,7 +3,7 @@
  *
  */
 var Protocol = function(options) {
-  this.debug = options.debug ? console.log.bind(console) : function() {};
+  this.debug = options.debug;
 
   this.board = options.board;
   this.connection = options.connection;

--- a/tests/protocol.spec.js
+++ b/tests/protocol.spec.js
@@ -15,7 +15,7 @@ var DEF_OPTS3 = {
     protocol: 'stk500v1'
   },
   connection: {},
-  debug: false
+  debug: function() {}
 };
 
 test('[ Protocol ]  - new creation', function(t) {


### PR DESCRIPTION
This allows the library users custom debug function to be used within the protocol layers. `avrgirl-arduino.js` currently guarantees a function is passed in as `options.debug`.

An alternative, is to have similar code to `avrgirl-arduino.js` in `lib/protocol.js`:

```js
  if (options.debug === true) {
    this.debug = console.log.bind(console);
  } else if (typeof options.debug === 'function') {
    this.debug = options.debug;
  } else {
    this.debug = function() {};
  }
```

Let know know which option is preferred.