### PR TITLE
Add Genuino Micro product id

### DIFF
--- a/boards.js
+++ b/boards.js
@@ -13,7 +13,7 @@ var boards = [
     name: 'micro',
     baud: 57600,
     signature: new Buffer([0x43, 0x41, 0x54, 0x45, 0x52, 0x49, 0x4e]),
-    productId: ['0x0037', '0x8037', '0x0036'],
+    productId: ['0x0037', '0x8037', '0x0036', '0x0237'],
     protocol: 'avr109'
   },
   {


### PR DESCRIPTION
A simple change to get my Genuino Micro board flashing.

0x8037 is present in the list already but the bootloader PID is 0x0237, which is needed to detect the boards after a CDC reset.

This also corresponds to the following entry in the AVR core: https://github.com/arduino/Arduino/blob/master/hardware/arduino/avr/boards.txt#L353