### PR TITLE
Updated package.json to change from git: to https:

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,14 +30,14 @@
   "dependencies": {
     "async": "^2.1.2",
     "awty": "^0.1.0",
-    "browser-serialport": "git://github.com/noopkat/browser-serialport#api-updates",
+    "browser-serialport": "https://github.com/noopkat/browser-serialport#api-updates",
     "chip.avr.avr109": "^1.1.0",
     "colors": "^1.1.2",
     "graceful-fs": "^4.1.2",
     "intel-hex": "^0.1.1",
     "minimist": "^1.2.0",
     "serialport": "^4.0.1",
-    "stk500": "git://github.com/noopkat/js-stk500v1#avrgirl",
+    "stk500": "https://github.com/noopkat/js-stk500v1#avrgirl",
     "stk500-v2": "^1.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Changed to https so those behind firewalls can install avrgirl without SSH access.

I work at a company that prohibits SSH access out of the network.  Since two of the dependencies had git: URLs instead of HTTPS, I was unable to install this at work.  I changed the package.json to use all https: URLs instead and it worked perfectly.

Thanks,
- James