### PR TITLE
Support devices that can't be reset from software

### DIFF
--- a/lib/avr109.js
+++ b/lib/avr109.js
@@ -102,6 +102,10 @@ Avr109.prototype._reset = function(callback) {
   var _this = this;
   var conn;
 
+  if (_this.board.manualReset) {
+    return callback(null);
+  }
+
   // creating a temporary connection for resetting only
   var tempSerialPort = new Serialport(_this.connection.options.port, {
     baudRate: 1200,


### PR DESCRIPTION
There are some devices out there that can't be reset from software, and need a physical button pressed to put them into bootloader mode. On these devices, trying to reset them is not going to work, so it is best skipped.

As such, this little change adds a `manualReset` flag to the board options, which when set, allows `Avr109._reset` to return immediately, skipping the whole reset dance. As a consequence, boards with the flag set, will have to be reset by the user before calling the `_upload` (or `avrgirl.flash`) method.

Tested & works on the Shortcut keyboard, and fixes #111.

Please let me know if you don't like the name of the flag - or anything else with the pull request - and I'll update it accordingly!