### PR TITLE
setting the rts pin to false when the dtr pin is used to reset boards.

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -83,7 +83,7 @@ Connection.prototype._sniffPort = function(callback) {
 Connection.prototype._setDTR = function(bool, timeout, callback) {
   var _this = this;
   var props = {
-    rts: bool,
+    rts: false,
     dtr: bool
   };
 


### PR DESCRIPTION
Hi! I'm adding the Freaks Car (http://www.elecfreaks.com/estore/freakscar-robot-starter-kit-741.html) to Bitbloq ( our robot/boards family is growing 😄 )

But when i try to program it with avrGirl always give me a timeout, i was searching and it's because the board never resets on the flashing process. 
I see that the reset is done in avrgir setting the DTR and RTS pins to true.
But setting DTR to true, and RTS to false it works.
I try with a bqZum and with an Arduino UNO, and works too. So i created the pull request because looks good. 
Buuut I'm not sure if this change can affect to more boards, i'm searching more info about the reset process on Arduino, but only see information about the DTR pin, never about the RTS, i'm not sure if is used too.
Can you test it in the other boards? if you find some board with errors setting the RTS to false, i can change the pull request to add a RTS option in the boards.json to handle this case in the reset.

Thanks!