### PR TITLE
Provide a static helper to list known boards

### DIFF
--- a/avrgirl-arduino.js
+++ b/avrgirl-arduino.js
@@ -111,4 +111,11 @@ AvrgirlArduino.prototype.list = AvrgirlArduino.list = function(callback) {
   return Connection.prototype._listPorts(callback);
 };
 
+/**
+ * Static method to return the names of all known boards.
+ */
+AvrgirlArduino.listKnownBoards = function() {
+  return Object.keys(boards.byName);
+};
+
 module.exports = AvrgirlArduino;

--- a/avrgirl-arduino.js
+++ b/avrgirl-arduino.js
@@ -30,7 +30,7 @@ var AvrgirlArduino = function(opts) {
   }
 
   if (typeof this.options.board === 'string') {
-    this.options.board = boards.byName[this.options.board];
+    this.options.board = boards[this.options.board];
   } else if (typeof this.options.board === 'object') {
     this.options.board = this.options.board;
   }
@@ -115,7 +115,13 @@ AvrgirlArduino.prototype.list = AvrgirlArduino.list = function(callback) {
  * Static method to return the names of all known boards.
  */
 AvrgirlArduino.listKnownBoards = function() {
-  return Object.keys(boards.byName);
+  // filter the boards to find all non-aliases
+  return Object.keys(boards).filter(function(name) {
+    // fetch the current board aliases
+    var aliases = boards[name].aliases;
+    // only allow the name if it's not an alias
+    return !aliases || !~aliases.indexOf(name);
+  });
 };
 
 module.exports = AvrgirlArduino;

--- a/boards.js
+++ b/boards.js
@@ -88,19 +88,8 @@ var boards = [
     productId: ['0x6001'],
     protocol: 'stk500v1'
   },
-  // this is here because of an accidental naming change of the tinyduino
+  // the alias is here because of an accidental naming change of the tinyduino
   // keeping in for backwards compatibility (SHA 05d65842)
-  {
-    name: 'tinduino',
-    baud: 57600,
-    signature: new Buffer([0x1e, 0x95, 0x0f]),
-    pageSize: 128,
-    numPages: 256,
-    timeout: 400,
-    productId: ['0x6015'],
-    protocol: 'stk500v1'
-  },
-  // correct naming of tinyduino
   {
     name: 'tinyduino',
     baud: 57600,
@@ -109,7 +98,8 @@ var boards = [
     numPages: 256,
     timeout: 400,
     productId: ['0x6015'],
-    protocol: 'stk500v1'
+    protocol: 'stk500v1',
+    aliases: ['tinduino']
   },
   {
     name: 'bqZum',
@@ -208,7 +198,7 @@ var boards = [
     signature: new Buffer([0x43, 0x41, 0x54, 0x45, 0x52, 0x49, 0x4e]),
     productId: ['0x0041', '0x8041'],
     protocol: 'avr109'
-  },
+  }
 ];
 
 /**
@@ -220,10 +210,18 @@ function boardLookupTable() {
   for (var i = 0; i < boards.length; i++) {
     var currentBoard = boards[i];
     byBoard[currentBoard.name] = currentBoard;
+
+    var aliases = currentBoard.aliases;
+    if (Array.isArray(aliases)) {
+      for (var j = 0; j < aliases.length; j++) {
+        var currentAlias = aliases[j];
+        byBoard[currentAlias] = currentBoard;
+      }
+    }
   }
   return byBoard;
 }
 
 module.exports = {
   byName: boardLookupTable()
-}
+};

--- a/boards.js
+++ b/boards.js
@@ -222,6 +222,4 @@ function boardLookupTable() {
   return byBoard;
 }
 
-module.exports = {
-  byName: boardLookupTable()
-};
+module.exports = boardLookupTable();


### PR DESCRIPTION
This PR is a resolution for #122.

It exposes a new static method named `listKnownBoards` using the keys from the `byName` object which is keyed by the board name. I went with this over `listBoards` as I figured that might be useful in future as an instance method which also includes things such as custom boards.

I also added aliasing to remove the duplication mentioned in the stream today, and verified that both names come back appropriately in the resulting call to `listKnownBoards`. It might be that we don't want the aliases to come back in this list though, if so just let me know and I can tweak it to omit them.

Here's an example output:

```javascript
> avr.listKnownBoards()
[ 'uno',
  'micro',
  'imuduino',
  'leonardo',
  'arduboy',
  'feather',
  'little-bits',
  'blend-micro',
  'nano',
  'duemilanove168',
  'duemilanove328',
  'tinyduino',
  'tinduino',
  'bqZum',
  'mega',
  'adk',
  'sf-pro-micro',
  'pro-mini',
  'qduino',
  'pinoccio',
  'lilypad-usb',
  'yun' ]
```

Feel free to make any changes you think should be made, or just let me know and I can make them as needed :D! 