### PR TITLE
Adds husky precommit for commit and push

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,10 @@ AVRGirl Arduino has a built-in manual testing tool called Test Pilot. It allows 
 
 Once AVRGirl Arduino is globally installed on your machine using `npm install -g avrgirl-arduino@latest`, type `avrgirl-arduino test-pilot` into your terminal program and follow the prompts. Shouldn't take more than two minutes of your time, but will make a big difference to ensuring any issues are reported and fixed promptly!
 
+## Auto unit testing
+
+AVRGirl Arduino has built-in support for automated unit testing on _push_ and _commit_. When either of these git commands are used, the test command, `npm run test` is invoked. __Note:__ this does not run Test Pilot.
+
 ## Feature requests
 
 The best thing to do here is to file an issue if there already isn't one. If it's something fairly obviously needed (in your opinion) and you are happy to code it, feel free to open a pull request without filing an issue first.
@@ -26,9 +30,11 @@ On average, Arduino boards cost between $15 and $50, depending on the tech inclu
 
 ## Code contribution workflow
 
+The steps below show you how to fork, install, work on, and sync back with the main repository.
+
 1. Fork this repository and clone the new fork locally. 
 
-2. Run `npm install` to install the dev dependencies.
+2. Run `npm install` to install the all dependencies.
 
 3. Make your changes in a new git branch: `git checkout -b my-fix-branch master`
 
@@ -36,7 +42,7 @@ On average, Arduino boards cost between $15 and $50, depending on the tech inclu
 
 5. Create your patch/feature, including appropriate tests if a test suite is present
 
-6. Commit your changes using a descriptive commit message
+6. Commit your changes using a descriptive commit message.
 
 7. Rebase on master if your branch falls behind on commits
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "main": "avrgirl-arduino.js",
   "scripts": {
     "test": "gulp test",
-    "cover": "istanbul cover ./tests/*.spec.js && istanbul-coveralls"
+    "cover": "istanbul cover ./tests/*.spec.js && istanbul-coveralls",
+    "precommit": "npm test",
+    "prepush": "npm test"
   },
   "repository": {
     "type": "git",
@@ -46,6 +48,7 @@
     "gulp-jscs": "^4.0.0",
     "gulp-jshint": "^2.0.3",
     "gulp-tape": "0.0.9",
+    "husky": "^0.13.4",
     "istanbul": "^0.4.0",
     "istanbul-coveralls": "^1.0.3",
     "jshint": "^2.9.2",


### PR DESCRIPTION
All commits and pushes now force npm test. Note you can use the `-n` flag to force up (always handy to have that)

- [x] add flag
- [x] update docs
- [x] add some info to PR for contextual use

## Context

Related to #124 This PR only covers the Husky part since this is non controversial. With this PR any commits or pulls will be ran against Unit Tests (not Test Pilot though, that would cause chaos); specifically `npm run test`.

@noopkat Lemme know if you need any more context, info, or changes.