### PR TITLE
Adds coverage npm cmd that doesn't report to coveralls

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "main": "avrgirl-arduino.js",
   "scripts": {
     "test": "gulp test",
+    "coverage": "istanbul cover ./tests/*.spec.js",
     "cover": "istanbul cover ./tests/*.spec.js && istanbul-coveralls"
   },
   "repository": {


### PR DESCRIPTION
Simple addition, it stops coverage failing all over the place locally (since cover should only be called by Travis).