### PR TITLE
Semantic commits and release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: node_js
+cache:
+  directories:
+    - node_modules
 node_js:
 - "7"
 - "6"
@@ -19,9 +22,15 @@ addons:
     - libudev-dev
 
 before_script:
+- npm prune
 - npm install -g gulp
 - npm install -g istanbul
 - npm install -g istanbul-coveralls
 
 after_success:
 - npm run cover
+- npm run semantic-release
+
+branches:
+  only:
+    - master

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,9 @@ On average, Arduino boards cost between $15 and $50, depending on the tech inclu
 
 5. Create your patch/feature, including appropriate tests if a test suite is present
 
-6. Commit your changes using a descriptive commit message
+6. Once you are ready to commit your changes, follow the commit [convention](https://github.com/conventional-changelog-archived-repos/conventional-changelog-angular/blob/ed32559941719a130bb0327f886d6a32a8cbc2ba/convention.md) through the use of `commitizen`:
+    1. `git add <files to be committed>`
+    2. `npm run commit` and follow the instruction of the interactive prompt.
 
 7. Rebase on master if your branch falls behind on commits
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "main": "avrgirl-arduino.js",
   "scripts": {
     "test": "gulp test",
-    "cover": "istanbul cover ./tests/*.spec.js && istanbul-coveralls"
+    "cover": "istanbul cover ./tests/*.spec.js && istanbul-coveralls",
+    "commit": "git-cz",
+    "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
   "repository": {
     "type": "git",
@@ -42,6 +44,8 @@
   },
   "devDependencies": {
     "avrga-tester": "1.x",
+    "commitizen": "2.9.6",
+    "cz-conventional-changelog": "2.0.0",
     "gulp": "^3.9.0",
     "gulp-jscs": "^4.0.0",
     "gulp-jshint": "^2.0.3",
@@ -51,6 +55,7 @@
     "jshint": "^2.9.2",
     "jshint-stylish": "^2.1.0",
     "proxyquire": "^1.7.3",
+    "semantic-release": "6.3.6",
     "sinon": "^2.3.2",
     "tap-spec": "^4.1.0",
     "tape": "^4.2.1",
@@ -59,5 +64,10 @@
   "browser": {
     "graceful-fs": false,
     "serialport": "browser-serialport"
+  },
+  "config": {
+    "commitizen": {
+      "path": "cz-conventional-changelog"
+    }
   }
 }


### PR DESCRIPTION
Following up the discussion on #124, this PR has the necessary packages and setup for semantic releases by following a commit [convention](https://github.com/conventional-changelog-archived-repos/conventional-changelog-angular/blob/master/index.js).

I also updated the Contributing guide to reflect the changes.

This still needs @noopkat to **install [semantic-release-cli](https://github.com/semantic-release/cli#what-it-does) globally** and run `semantic-release-cli setup` in order to setup the npm and github credentials for the release.

**so maybe this PR should go be merged into another branch, before heading to master.**