### PR TITLE
Added support for Circuit Playground Classic in boards.js

### DIFF
--- a/boards.js
+++ b/boards.js
@@ -207,7 +207,7 @@ var boards = [
     protocol: 'avr109'
   }, 
   {
-    name: 'circuit-playground',
+    name: 'circuit-playground-classic',
     baud: 57600,
     signature: new Buffer([0x43, 0x41, 0x54, 0x45, 0x52, 0x49, 0x4e]),
     productId: ['0x0011', '0x8011'],

--- a/boards.js
+++ b/boards.js
@@ -205,6 +205,13 @@ var boards = [
     signature: new Buffer([0x43, 0x41, 0x54, 0x45, 0x52, 0x49, 0x4e]),
     productId: ['0x003C', '0x803C'],
     protocol: 'avr109'
+  }, 
+  {
+    name: 'circuit-playground',
+    baud: 57600,
+    signature: new Buffer([0x43, 0x41, 0x54, 0x45, 0x52, 0x49, 0x4e]),
+    productId: ['0x0011', '0x8011'],
+    protocol: 'avr109'
   }
 ];
 


### PR DESCRIPTION
It works on my Windows 10 computer. 