### PR TITLE
Adafruit Circuit Playground Test

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ The current supported list:
 + **Pinoccio Scout**
 + **Adafruit Feather 32u4 Basic Proto**
 + **Arduboy**
++ **Adafruit Circuit Playground**
 
 This library is designed to ultimately be rolled into the avrgirl project (in development), however it still works perfectly well as a stand-alone package to be used outside of avrgirl if you wish.
 
@@ -104,6 +105,7 @@ When creating `new Avrgirl()`, only the `board` property is required. The board 
 |Femtoduino IMUduino|`imuduino`|
 |Adafruit Feather 32u4 Basic Proto|`feather`|
 |Arduboy|`arduboy`|
+|Adafruit Circuit Playground|`circuit-playground-classic`|
 
 You can optionally specify a port to connect to the Arduino, but if you omit this property avrgirl-arduino will do a pretty good job of finding it for you. **The exception to this is if you're using the Arduino Pro Mini - please specify your port in this case as avrgirl-arduino cannot auto detect it for you.**
 
@@ -279,3 +281,4 @@ Credit to [Jacob Rosenthal](https://github.com/jacobrosenthal), [Ryan Day](https
 + [Tom Calvo](https://github.com/tocalvo)
 + [Kimio Kosaka](https://github.com/kimio-kosaka)
 + [Sandeep Mistry](https://github.com/sandeepmistry)
++ [Nick Hehr](https://github.com/hipsterbrown)

--- a/tests/demos/circuit-playground-classic.js
+++ b/tests/demos/circuit-playground-classic.js
@@ -1,0 +1,16 @@
+var Avrgirl = require('../../avrgirl-arduino');
+
+var avrgirl = new Avrgirl({
+  board: 'circuit-playground-classic',
+  debug: true
+});
+
+var hex = __dirname + '/../../junk/hex/circuit-playground-classic/Blink.cpp.hex';
+
+avrgirl.flash(hex, function(error) {
+  if (error) {
+    console.error(error);
+  } else {
+    console.log('done.');
+  }
+});


### PR DESCRIPTION
I tested the recent release of `avrgirl-arduino` with support for the [Adafruit Circuit Playground Classic](https://www.adafruit.com/product/3000) against the board. 

**Result:**
```
hipsterbrown:avrgirl-arduino (master) $ node tests/demos/circuit-playground-classic.js
found circuit-playground-classic on port /dev/cu.usbmodem1421
resetting board...
reset complete.
connected
flashing, please wait...
flash complete.
done.
hipsterbrown:avrgirl-arduino (master) $
```

**Success!!!** :tada:

This PR adds a test demo file for the `circuit-playground-classic` and updates the README to include the board in the supported boards list (I also added myself to the list of contributors if this is approved).