### PR TITLE
[uno] add sparkfun redboard productId

### DIFF
--- a/boards.js
+++ b/boards.js
@@ -6,7 +6,7 @@ var boards = [
     pageSize: 128,
     numPages: 256,
     timeout: 400,
-    productId: ['0x0043', '0x7523', '0x0001', '0xea60'],
+    productId: ['0x0043', '0x7523', '0x0001', '0xea60', '0x6015'],
     productPage: 'https://store.arduino.cc/arduino-uno-rev3',
     protocol: 'stk500v1'
   },


### PR DESCRIPTION
# Description

Add Sparkfun [Redboard](https://www.sparkfun.com/products/13975) to the boards.js `uno` section.  The board is compatible with Arduino Uno.

# Features
-  ATmega328 microcontroller with Optiboot (UNO) Bootloader
-  USB Programming Facilitated by the Ubiquitous FTDI FT231X
-  Input voltage - 7-15V
-  0-5V outputs with 3.3V compatible inputs
-  14 Digital I/O Pins (6 PWM outputs)
-  6 Analog Inputs
-  ISP Header
-  32k Flash Memory
-  16MHz Clock Speed
-  All SMD Construction
-  R3 Shield Compatible
-  Red PCB!