### PR TITLE
 Add boards entry for Nano with new bootloader

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ When creating `new Avrgirl()`, only the `board` property is required. The board 
 |Arduino Leonardo|`leonardo`|
 |Arduino Micro|`micro`|
 |Arduino Nano|`nano`|
+|Arduino Nano (with new bootloader)|`nano (New Bootloader)`|
 |Arduino Lilypad USB|`lilypad-usb`|
 |Arduino Duemilanove|`duemilanove168`|
 |Arduino Yun|`yun`|
@@ -241,7 +242,7 @@ The same example above would look like the following as a CLI call in your shell
 Required flags:
 
 + **-f** specify the location of the hex file to flash
-+ **-a** specify the name of the Arduino (`uno`, `mega`,`leonardo`, `micro`, `nano`, `pro-mini`, `duemilanove168`, `yun`, `esplora`, `blend-micro`, `tinyduino`, `sf-pro-micro`, `qduino`, `pinoccio`, `feather`, or `imuduino`)
++ **-a** specify the name of the Arduino (`uno`, `mega`,`leonardo`, `micro`, `nano`, `"nano (New Bootloader)"`, `pro-mini`, `duemilanove168`, `yun`, `esplora`, `blend-micro`, `tinyduino`, `sf-pro-micro`, `qduino`, `pinoccio`, `feather`, or `imuduino`)
 
 Optional flags:
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ When creating `new Avrgirl()`, only the `board` property is required. The board 
 |Arduino Leonardo|`leonardo`|
 |Arduino Micro|`micro`|
 |Arduino Nano|`nano`|
-|Arduino Nano (with new bootloader)|`nano (New Bootloader)`|
+|Arduino Nano (with new bootloader)|`nano (new bootloader)`|
 |Arduino Lilypad USB|`lilypad-usb`|
 |Arduino Duemilanove|`duemilanove168`|
 |Arduino Yun|`yun`|

--- a/boards.js
+++ b/boards.js
@@ -69,6 +69,16 @@ var boards = [
     protocol: 'stk500v1'
   },
   {
+    name: 'nano (New Bootloader)',
+    baud: 115200,
+    signature: new Buffer([0x1e, 0x95, 0x0f]),
+    pageSize: 128,
+    numPages: 256,
+    timeout: 400,
+    productId: ['0x6001', '0x7523'],
+    protocol: 'stk500v1'
+  },
+  {
     name: 'duemilanove168',
     baud: 19200,
     signature: new Buffer([0x1e, 0x94, 0x06]),

--- a/boards.js
+++ b/boards.js
@@ -69,7 +69,7 @@ var boards = [
     protocol: 'stk500v1'
   },
   {
-    name: 'nano (New Bootloader)',
+    name: 'nano (new bootloader)',
     baud: 115200,
     signature: new Buffer([0x1e, 0x95, 0x0f]),
     pageSize: 128,


### PR DESCRIPTION
# Description

This change adds a new boards entry for Arduino Nano boards that ship with the new bootloader (baud 115200).

The corresponding change in the Arduino AVR core can be found here: https://github.com/arduino/ArduinoCore-avr/commit/1b14cc07331268e95eddcce2cc67e29ed667e62f

Note: instead of changing the current nano entry, I've opted to add a new one for backwards compatibility.

cc/ @facchinm

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] Changes have been manually tested (please provide information on test platform using the fields below)

## Test / Development Platform Information

- Operating system and version: macOS 10.14.2
- Avrgirl Arduino version: master / c502da52354514cba5fef9ef6bfad297d82e7d8d
- NodeJS version: v10.15.0 
- Arduino Board being used: Arduino Nano with new boot loader (115200 baud)