### PR TITLE
stk500v1: reset like avrdude - DTR low 250 ms, then DTR high 50 ms

### DIFF
--- a/lib/stk500v1.js
+++ b/lib/stk500v1.js
@@ -58,12 +58,16 @@ Stk500v1.prototype._upload = function(file, callback) {
 Stk500v1.prototype._reset = function(callback) {
   var _this = this;
 
-  _this.connection._setDTR(true, 250, function(error) {
-    if (!error) {
-      _this.debug('reset complete.');
-    }
+  _this.connection._setDTR(false, 250, function(error) {
+    if (error) { return callback(error); }
 
-    return callback(error);
+    _this.connection._setDTR(true, 50, function(error) {
+      if (!error) {
+        _this.debug('reset complete.');
+      }
+
+      return callback(error);
+    });
   });
 };
 


### PR DESCRIPTION
# Description

While tracking down some "Sending 3020: receiveData timeout after 400ms" STK500v1 errors on Chrome OS 74, I noticed the stk500v1 reset code in this project does not match the procedure in`avrdude`: https://github.com/kcuzner/avrdude/blob/master/avrdude/arduino.c#L95-L104

The port open is fast enough to trigger a reset and perform uploads. However if you add a `setTimeout` of 5 seconds after `_this.serialPort.open(function(error) {` in [stk500v1.js](https://github.com/noopkat/avrgirl-arduino/blob/master/lib/stk500v1.js) the board doesn't actually reset (it's still running the previously loaded sketch).

For Chrome OS 74, the following `stk500` pull request was also needed for sequential uploads to work without unplugging the USB cable: https://github.com/jacobrosenthal/js-stk500v1/pull/9

Happy to provide further info or perform more testing if required.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] Changes have been manually tested (please provide information on test platform using the fields below)

## Test / Development Platform Information

- Operating system and version: Chrome OS 75, macOS 10.4.4
- Avrgirl Arduino version: master
- NodeJS version: 10.15.0
- Arduino Board being used: Arduino Uno