### PR TITLE
Adding support for custom boards in the cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,22 @@ As well as listing all available USB devices on your computer:
 
 The output will be presented in JSON format, very similar to the output of the `Serialport.list()` method (if you've used [node-serialport](https://github.com/voodootikigod/node-serialport) before).
 
+## Custom board specification
+
+When specifying a custom board object, a number of properties must be provided:
+
++ `name`: the name of the board, used in debug and error messages
++ `baud`: the data rate for data transmission
++ `signature`: a `Buffer` containing the device signature
++ `productId`: an array of valid USB product IDs for the board
++ `protocol`: the board communication protocol (`avr109`, `stk500v1` and `stk500v2` are currently supported)
+
+If using the `stk500v2` protocol, you also need to specify:
+
++ `pageSize`: the size of the page used to load programs
+
+The other board specification properties are optional. You may look at `boards.js` for more details.
+
 ## Sourcing a compiled Arduino hex file
 
 A .hex file is the compiled end result of an Arduino sketch file. I have provided some example hex files for each board within the `junk/hex` folder of this repo. Feel free to use these, or if you're after something specific not provided, see the directions below.

--- a/README.md
+++ b/README.md
@@ -244,7 +244,21 @@ Required flags:
 + **-f** specify the location of the hex file to flash
 + **-a** specify the spcification of the Arduino. It can be:
   + the name of the Arduino (`uno`, `mega`,`leonardo`, `micro`, `nano`, `"nano (new bootloader)"`, `pro-mini`, `duemilanove168`, `yun`, `esplora`, `blend-micro`, `tinyduino`, `sf-pro-micro`, `qduino`, `pinoccio`, `feather`, or `imuduino`)
-  + a JSON file describing a custom board
+  + a JavaScript file describing a custom board
+
+When using a custom board, the JavaScript file must export the board specification:
+
+```javascript
+var board = {
+  name: 'micro',
+  baud: 57600,
+  signature: new Buffer([0x43, 0x41, 0x54, 0x45, 0x52, 0x49, 0x4e]),
+  productId: ['0x0037', '0x8037', '0x0036'],
+  protocol: 'avr109',
+};
+
+module.exports = board;
+```
 
 Optional flags:
 

--- a/README.md
+++ b/README.md
@@ -242,7 +242,9 @@ The same example above would look like the following as a CLI call in your shell
 Required flags:
 
 + **-f** specify the location of the hex file to flash
-+ **-a** specify the name of the Arduino (`uno`, `mega`,`leonardo`, `micro`, `nano`, `"nano (new bootloader)"`, `pro-mini`, `duemilanove168`, `yun`, `esplora`, `blend-micro`, `tinyduino`, `sf-pro-micro`, `qduino`, `pinoccio`, `feather`, or `imuduino`)
++ **-a** specify the spcification of the Arduino. It can be:
+  + the name of the Arduino (`uno`, `mega`,`leonardo`, `micro`, `nano`, `"nano (new bootloader)"`, `pro-mini`, `duemilanove168`, `yun`, `esplora`, `blend-micro`, `tinyduino`, `sf-pro-micro`, `qduino`, `pinoccio`, `feather`, or `imuduino`)
+  + a JSON file describing a custom board
 
 Optional flags:
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -35,26 +35,23 @@ function flash(file, options) {
 function handlePotentialCustomBoardFile(filename) {
   const filepath = path.resolve(process.cwd(), filename);
 
-  let contents;
-  try {
-    contents = fs.readFileSync(filepath, 'utf8');
-  } catch (error) {
+  if (!fs.existsSync(filepath)) {
     // let's try to provide a more precise error if it looks like a real filename
     if (filename.includes('.') || filename.includes(path.sep)) {
-      console.error(new Error('Oops! We could not read the custom board JSON file.'));
+      console.error(new Error('Oops! We could not read the custom board file.'));
       process.exit(1);
     }
     return;
   }
 
-  try {
-    let board = JSON.parse(contents);
-    board.signature = Buffer.from(board.signature);
-    return board;
-  } catch (error) {
-    console.error(new Error('Oops! The custom board JSON file is invalid.'));
+  const board = require(filepath);
+
+  if (!board) {
+    console.error(new Error('Oops! It seems like the custom board file does not export \'board\'.'));
     process.exit(1);
   }
+
+  return board;
 }
 
 function handleInput(action, argz) {


### PR DESCRIPTION
Fixes #97

This PR allows to provide a custom board specification in the CLI, eg:
```
avrgirl-arduino flash -f Blink.cpp.hex -a custom.json
```

This change being in the CLI part, I am not sure what is the appropriate way to test it.

There is currently not a lot of documentation for custom boards (looking at you #151), so I did not add documentation on the expected JSON format. The only tricky part, I think, is the `signature` field where we create the `Buffer` from the input JSON array. Maybe adding a CLI option to display the JSON specification for a supported board may help ?

Maybe we want to the feature to the library part? It may make sense to handle the `Buffer` creation for the user.

I tried to provide an accurate error message, but using the same argument, it is kind of hard to discriminate between a board name and a JSON file.
