### PR TITLE
Adding support for sparse custom board

### DIFF
--- a/avrgirl-arduino.js
+++ b/avrgirl-arduino.js
@@ -29,6 +29,14 @@ var AvrgirlArduino = function(opts) {
     this.debug = function() {};
   }
 
+  // handle 'sparse' boards, ie. boards with only the 'name' property defined
+  if (typeof this.options.board === 'object') {
+    const properties = Object.getOwnPropertyNames(this.options.board);
+    if ((properties.length === 1) && (properties[0] === 'name')) {
+      this.options.board = this.options.board.name;
+    }
+  }
+
   if (typeof this.options.board === 'string') {
     this.options.board = boards[this.options.board];
   }

--- a/tests/avrgirl-arduino.spec.js
+++ b/tests/avrgirl-arduino.spec.js
@@ -63,6 +63,24 @@ test('[ AVRGIRL-ARDUINO ] ::_validateBoard (GOOD)', function(t) {
   });
 });
 
+test('[ AVRGIRL-ARDUINO ] ::_validateBoard (SPARSE)', function(t) {
+  t.plan(1);
+
+  var a = new Avrgirl({ board: { name: DEF_OPTS2.board } });
+  a._validateBoard(function(error) {
+    t.error(error, 'no error');
+  });
+});
+
+test('[ AVRGIRL-ARDUINO ] ::_validateBoard (SPARSE NO NAME)', function(t) {
+  t.plan(1);
+
+  var a = new Avrgirl({ board: { notName: DEF_OPTS2.board } });
+  a._validateBoard(function(error) {
+    t.ok(error, 'error returned');
+  });
+});
+
 test('[ AVRGIRL-ARDUINO ] ::_validateBoard (NO BOARD)', function(t) {
   t.plan(1);
 


### PR DESCRIPTION
Fixes #114

This change allows to define a sparse board object:  `new Avrgirl({ board: { name: 'uno' } })`.
To be valid, the `board` argument must be an object with only the `name` property defined (ie.  `new Avrgirl({ board: { name: 'uno', protocol: 'stk500v1' } })` will not be considered as sparse, and wiil fail latter because of missing properties).

Also adds associated tests.