### PR TITLE
webserial demo: script is utf-8

### DIFF
--- a/tests/demos/webserial/index.html
+++ b/tests/demos/webserial/index.html
@@ -39,7 +39,7 @@
         <div id="gear"><img src="images/gear4.svg"/></div>
       </div>
     </div>
-    <script src="/js/avrgirl-arduino.global.js"></script>
+    <script src="/js/avrgirl-arduino.global.js" charset="UTF-8"></script>
     <script>
       function handleSubmit(e) {
         e.preventDefault();


### PR DESCRIPTION
I couldn't get the js to load properly without having a charset attr on the <script>. Probably has something to do with my particular OS.