### PR TITLE
remove master branch trigger for changelog gh action

### DIFF
--- a/.github/workflows/gh-release.yml
+++ b/.github/workflows/gh-release.yml
@@ -1,8 +1,6 @@
 name: 'GitHub release'
 on:
   push:
-    branches:
-      - 'master'
     tags:
       - 'v*'
 jobs:


### PR DESCRIPTION
# Description

 We don't want the changelog github action to trigger on any push to master, just tags.