### PR TITLE
More browser support & port forwarding

### DIFF
--- a/avrgirl-arduino.js
+++ b/avrgirl-arduino.js
@@ -15,6 +15,7 @@ var injectDependencies = function(boards, Connection, protocols) {
       megaDebug: opts.megaDebug || false,
       board: opts.board || 'uno',
       port: opts.port || '',
+      serialPort: opts.serialPort || null,
       manualReset: opts.manualReset || false,
       disableVerify: opts.disableVerify || false
     };

--- a/lib/browser-serialport.js
+++ b/lib/browser-serialport.js
@@ -9,7 +9,7 @@ class SerialPort extends EventEmitter {
     this.browser = true;
     this.path = this.options.path;
     this.isOpen = false;
-    this.port = null;
+    this.port = port || null;
     this.writer = null;
     this.reader = null;
     this.baudRate = this.options.baudRate;
@@ -24,8 +24,13 @@ class SerialPort extends EventEmitter {
       .catch((error) => {if (callback) {return callback(error)}}); 
   }
 
+  async _getPort() {
+    if (this.port && !this.options.forceRequest) return this.port;
+    return window.navigator.serial.requestPort(this.requestOptions)
+  }
+
   open(callback) {
-    window.navigator.serial.requestPort(this.requestOptions)
+    this._getPort()
       .then(serialPort => {
         this.port = serialPort;
         if (this.isOpen) return;

--- a/lib/browser-serialport.js
+++ b/lib/browser-serialport.js
@@ -146,7 +146,10 @@ class SerialPort extends EventEmitter {
 
   async update (options, callback) {
     try {
-      if (Object.prototype.hasOwnProperty.call(options, 'baudRate')) {
+      if (
+        Object.prototype.hasOwnProperty.call(options, 'baudRate')
+        && this.baudRate !== options.baudRate
+      ) {
         if (this.isOpen) {
           // try to quietly close then open the port with the new baudRate
           this.isUpdating = true;

--- a/lib/browser-serialport.js
+++ b/lib/browser-serialport.js
@@ -80,6 +80,9 @@ class SerialPort extends EventEmitter {
         this.closeReadResolve = resolve;
       });
       this.pauseResolve();
+      try {
+        await this.reader.cancel();
+      } catch (err) { console.error(err); }
       await this.closeReadPromise;
       this.closeReadPromise = null;
     }

--- a/lib/browser-serialport.js
+++ b/lib/browser-serialport.js
@@ -15,6 +15,8 @@ class SerialPort extends EventEmitter {
     this.isUpdating = false;
     this.pausePromise = Promise.resolve();
     this.pauseResolve = () => {};
+    this.closeReadPromise = null;
+    this.closeReadResolve = () => {};
     this.baudRate = this.options.baudRate;
     this.requestOptions = this.options.requestOptions || {};
 
@@ -51,7 +53,7 @@ class SerialPort extends EventEmitter {
             try {
               await this.pausePromise;
               const { value, done } = await this.reader.read();
-              if (done) {
+              if (done || this.closeReadPromise) {
                 break;
               }
               this.emit('data', Buffer.from(value));
@@ -59,6 +61,7 @@ class SerialPort extends EventEmitter {
               console.error(e);
             }
           }
+          this.closeReadResolve();
         })
         .catch(error => {
           if (callback) callback(error);
@@ -71,6 +74,14 @@ class SerialPort extends EventEmitter {
     if (!this.isOpen) {
       if (callback) callback(null);
       return;
+    }
+    if (this.port.readable.locked) {
+      this.closeReadPromise = new Promise((resolve) => {
+        this.closeReadResolve = resolve;
+      });
+      this.pauseResolve();
+      await this.closeReadPromise;
+      this.closeReadPromise = null;
     }
     try {
       await this.reader.releaseLock();

--- a/lib/browser-serialport.js
+++ b/lib/browser-serialport.js
@@ -12,6 +12,9 @@ class SerialPort extends EventEmitter {
     this.port = port || null;
     this.writer = null;
     this.reader = null;
+    this.isUpdating = false;
+    this.pausePromise = Promise.resolve();
+    this.pauseResolve = () => {};
     this.baudRate = this.options.baudRate;
     this.requestOptions = this.options.requestOptions || {};
 
@@ -30,31 +33,38 @@ class SerialPort extends EventEmitter {
   }
 
   open(callback) {
-    this._getPort()
-      .then(serialPort => {
-        this.port = serialPort;
-        if (this.isOpen) return;
-        return this.port.open({ baudRate: this.baudRate || 57600 });
-      })
-      .then(() => this.writer = this.port.writable.getWriter())
-      .then(() => this.reader = this.port.readable.getReader())
-      .then(async () => {
-        this.emit('open');
-        this.isOpen = true;
-        callback(null);
-        while (this.port.readable.locked) {
-          try {
-            const { value, done } = await this.reader.read();
-            if (done) {
-              break;
+    return new Promise((resolve, reject) => {
+      this._getPort()
+        .then(serialPort => {
+          this.port = serialPort;
+          if (this.isOpen) return;
+          return this.port.open({ baudRate: this.baudRate || 57600 });
+        })
+        .then(() => this.writer = this.port.writable.getWriter())
+        .then(() => this.reader = this.port.readable.getReader())
+        .then(async () => {
+          if (!this.isUpdating) this.emit('open');
+          this.isOpen = true;
+          if (callback) callback(null);
+          resolve(null);
+          while (this.port.readable.locked) {
+            try {
+              await this.pausePromise;
+              const { value, done } = await this.reader.read();
+              if (done) {
+                break;
+              }
+              this.emit('data', Buffer.from(value));
+            } catch (e) {
+              console.error(e);
             }
-            this.emit('data', Buffer.from(value));
-          } catch (e) {
-            console.error(e);
           }
-        }
-      })
-      .catch(error => {callback(error)});
+        })
+        .catch(error => {
+          if (callback) callback(error);
+          reject(error);
+        });
+    });
   }
 
   async close(callback) {
@@ -62,6 +72,7 @@ class SerialPort extends EventEmitter {
       await this.reader.releaseLock();
       await this.writer.releaseLock();
       await this.port.close();
+      if (!this.isUpdating) this.emit('close');
       this.isOpen = false;
     } catch (error) {
       if (callback) return callback(error);
@@ -92,6 +103,27 @@ class SerialPort extends EventEmitter {
     if (callback) return callback(null);
   }
 
+  async get(callback) {
+    const props = {};
+    try {
+      const signals = await this.port.getSignals();
+      if (Object.prototype.hasOwnProperty.call(signals, 'dataCarrierDetect')) {
+        props.dcd = signals.dataCarrierDetect;
+      }
+      if (Object.prototype.hasOwnProperty.call(signals, 'clearToSend')) {
+        props.cts = signals.clearToSend;
+      }
+      if (Object.prototype.hasOwnProperty.call(signals, 'dataSetReady')) {
+        props.dsr = signals.dataSetReady;
+      }
+    } catch (error) {
+      if (callback) return callback(error);
+      throw error;
+    }
+    if (callback) return callback(props);
+    return props;
+  }
+
   write(buffer, callback) {
     this.writer.write(buffer);
     if (callback) return callback(null);
@@ -106,6 +138,37 @@ class SerialPort extends EventEmitter {
       throw error;
     }
     if (callback) callback(null, buffer);
+  }
+
+  async update (options, callback) {
+    try {
+      if (Object.prototype.hasOwnProperty.call(options, 'baudRate')) {
+        if (this.isOpen) {
+          // try to quietly close then open the port with the new baudRate
+          this.isUpdating = true;
+          await this.close();
+          this.baudRate = options.baudRate;
+          await this.open();
+          this.isUpdating = false;
+        } else {
+          this.baudRate = options.baudRate;
+        }
+      }
+    } catch (error) {
+      if (callback) return callback(error);
+      throw error;
+    }
+    if (callback) callback(null);
+  }
+
+  pause() {
+    this.pausePromise = new Promise((resolve) => {
+      this.pauseResolve = resolve;
+    });
+  }
+
+  resume() {
+    this.pauseResolve();
   }
 
   // TODO: is this correct?

--- a/lib/browser-serialport.js
+++ b/lib/browser-serialport.js
@@ -68,6 +68,10 @@ class SerialPort extends EventEmitter {
   }
 
   async close(callback) {
+    if (!this.isOpen) {
+      if (callback) callback(null);
+      return;
+    }
     try {
       await this.reader.releaseLock();
       await this.writer.releaseLock();
@@ -78,7 +82,7 @@ class SerialPort extends EventEmitter {
       if (callback) return callback(error);
       throw error;
     }
-    callback && callback(null);
+    if (callback) callback(null);
   }
 
   async set(props = {}, callback) {

--- a/lib/connection-browser.js
+++ b/lib/connection-browser.js
@@ -25,7 +25,7 @@ Connection.prototype._init = function(callback) {
  * Create new serialport instance for the Arduino board, but do not immediately connect.
  */
 Connection.prototype._setUpSerial = function(callback) {
-  this.serialPort = new Serialport('', {
+  this.serialPort = new Serialport(this.options.port, {
     baudRate: this.board.baud,
     autoOpen: false
   });

--- a/lib/connection-browser.js
+++ b/lib/connection-browser.js
@@ -25,14 +25,21 @@ Connection.prototype._init = function(callback) {
  * Create new serialport instance for the Arduino board, but do not immediately connect.
  */
 Connection.prototype._setUpSerial = function(callback) {
-  this.serialPort = new Serialport(this.options.port, {
-    baudRate: this.board.baud,
-    autoOpen: false
-  });
-  this.serialPort.on('open', function() {
-    //    _this.emit('connection:open');
-  })
-  return callback(null);
+  if (this.options.serialPort) {
+    this.serialPort = this.options.serialPort;
+    this.serialPort.update({ baudRate: this.board.baud }, function(error) {
+      return callback(error);
+    });
+  } else {
+    this.serialPort = new Serialport(this.options.port, {
+      baudRate: this.board.baud,
+      autoOpen: false
+    });
+    this.serialPort.on('open', function() {
+      //    _this.emit('connection:open');
+    })
+    return callback(null);
+  }
 };
 
 /**


### PR DESCRIPTION
# Description

Hey, I'm the maintainer of duino.app, an open-source browser-based Arduino programmer. I was looking at having to code browser-side uploading manually until I spotted that you had since added browser support!

This PR addresses some things to make the browser implementation a little more feature complete so I could use it in my application.

There are three main things done in this PR:
1. Allow passing/forwarding through an existing node-serial/web-serial port, in case the calling application has already gotten the user to select the serial port and/or is using it for other things like serial monitoring
2. Fill out some of the missing node-serial features
3. Close the connection more gracefully

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

The port forwarding is a pretty advanced use case, it's nice that it's there, but I'm uncertain if it should be "supported" by documenting it.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Changes have been manually tested (please provide information on test platform using the fields below)

## Test / Development Platform Information

- Operating system and version
Manjaro Linux
- Avrgirl Arduino version
latest
- NodeJS version
12.x
- Arduino Board being used
Uno, Mega